### PR TITLE
Correct, modernize and make more independent of user

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ then look for the *Billing* link in the navigation bar.
 1. In order for `ansible` to create Compute Engine instances, you'll need a
 [Service Account](https://cloud.google.com/compute/docs/access/service-accounts#serviceaccount). 
 It's recommended that you create a new Service Account (don't use the default), called 'demo-ansible', for this demo.
-Make sure to create a new JSON formatted private key file for this Service Account. Also, note the *Email address* 
-of this Service Account (should be `demo-ansible@YOUR_PROJECT_ID.iam.gserviceaccount.com`) since 
-this will be required in the Ansible configuration files.
+    1. Create a new JSON formatted private key file for this Service Account. Save it to your local machine in file `~/serviceaccounts/demo-ansible.json`.
+    1. Grant role _Compute Admin_ to the service account.
 
 1. Next you will want to install the
 [Cloud SDK](https://cloud.google.com/sdk/) and make sure you've
@@ -79,15 +78,18 @@ and demo files.
     git clone https://github.com/GoogleCloudPlatform/compute-video-demo-ansible
     ```
 
-1. Edit the `gce_vars/auth` file and specify your Project ID in the
-`project_id` variable, Service Account email address in the `service_account_email` variable,
-and the location of your JSON key (downloaded earlier) in the `credentials_file` variable.
+1. Edit the `gce_vars/auth` file and specify your Project ID as the
+`project` value. Note that the value of `credentials_file` is the name of the
+service account JSON file you saved earlier.
+
     ```
     ---
     # Google Compute Engine required authentication global variables
-    # (Replace 'YOUR_PROJECT_ID' with the Project ID used in creating your GCP project.)
-    project: YOUR_PROJECT_ID
-    service_account_file: /path/to/your/json_key_file
+    # (Set the value of `project` to the Project ID of your GCP project.)
+    project: team-agent
+    credentials_file: ~/serviceaccounts/demo-ansible.json
+    auth_kind: serviceaccount
+
     ```
 
 # Demo time!
@@ -135,10 +137,10 @@ of modules and instructions.
 ## Cleaning up
 
 When you're done with the demo, make sure to tear down all of your
-instances and clean-up. You will get charged for this usage and you will
+instances and cleanup. You will get charged for this usage and you will
 accumulate additional charges if you do not remove these resources.
 
-Fortunately, you can use the `clean-up.yml` playbook for destroying these
+Fortunately, you can use the `cleanup.yml` playbook to destroy these
 demo Compute Engine resources. The following command can be used to destroy
 all of the resources created for this demo.
 

--- a/gce_vars/auth
+++ b/gce_vars/auth
@@ -1,6 +1,6 @@
 ---
 # Google Compute Engine required authentication global variables
-# (Replace 'YOUR_PROJECT_ID' with the Project ID used in creating your GCP project.)
-project: google.com:graphite-playground
-credentials_file: ~/serviceaccounts/drawfork.json
+# (Set the value of `project` to the Project ID of your GCP project.)
+project: team-agent
+credentials_file: ~/serviceaccounts/demo-ansible.json
 auth_kind: serviceaccount

--- a/group_vars/all
+++ b/group_vars/all
@@ -3,5 +3,5 @@
 #
 # Variables to be set for dynamic hosts.
 ---
-ansible_ssh_user: alexstephen
-ansible_ssh_private_key_file: /Users/alexstephen/.ssh/google_compute_engine
+ansible_ssh_user: "{{ lookup('env', 'USER') }}"
+ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,6 @@
 ---
 # compute-video-demo-ansible
-- include: gce-instances.yml
-- include: web.yml
-- include: gce-lb.yml
+
+- import_playbook: gce-instances.yml
+- import_playbook: web.yml
+- import_playbook: gce-lb.yml


### PR DESCRIPTION
The playbook had drifted away from the text of `README.md`, so I corrected what I could.

I eliminated literal user name.

I modified the instructions so the `credentials_file` name is constant.

I modified the instructions so that the current value of `project` in `gce_vars/auth` need not be
`YOUR_PROJECT_ID`. This is because it is too easy to forget to change this value from an
actual project ID to `YOUR_PROJECT_ID` before committing.

Replaced deprecated `include` with `import_playbook`.

There is no file `clean-up.yml`, so I corrected it to `cleanup.yml`. Although I did not say or do
anything about it, `cleanup.yml` is quite broken.